### PR TITLE
Update TPSTwitterModule.m

### DIFF
--- a/ios/TPSTwitterModule/TPSTwitterModule.m
+++ b/ios/TPSTwitterModule/TPSTwitterModule.m
@@ -194,4 +194,9 @@ RCT_EXPORT_METHOD(login:(RCTPromiseResolveBlock)resolve
     return errorCode;
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
 @end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tipsi-twitter",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Twitter sdk for react-native",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
Module TPSTwitterModule requires main queue setup since it overrides `constantsToExport` but doesn't implement `requiresMainQueueSetup`. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of.
